### PR TITLE
Use the new Bionic module from Swift 6 where possible

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -326,7 +326,12 @@ open class FileHandle : NSObject, @unchecked Sendable {
             if options.contains(.alwaysMapped) {
                 // Filesizes are often 64bit even on 32bit systems
                 let mapSize = min(length, Int(clamping: statbuf.st_size))
+              #if canImport(Android)
+                // Bionic mmap() now returns _Nonnull, so the force unwrap below isn't needed.
                 let data = mmap(nil, mapSize, PROT_READ, MAP_PRIVATE, _fd, 0)
+              #else
+                let data = mmap(nil, mapSize, PROT_READ, MAP_PRIVATE, _fd, 0)!
+              #endif
                 // Swift does not currently expose MAP_FAILURE
                 if data != UnsafeMutableRawPointer(bitPattern: -1) {
                     return NSData.NSDataReadResult(bytes: data, length: mapSize) { buffer, length in

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -21,8 +21,8 @@ import WinSDK
 
 #if os(WASI)
 import WASILibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -11,8 +11,8 @@
 
 #if canImport(Glibc)
 import Glibc
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -22,8 +22,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // NOTE: this represents PLATFORM_PATH_STYLE

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -933,13 +933,6 @@ open class Process: NSObject, @unchecked Sendable {
 #else
         var spawnAttrs: posix_spawnattr_t = posix_spawnattr_t()
 #endif
-#if os(Android)
-        guard var spawnAttrs else {
-            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: [
-                    NSURLErrorKey:self.executableURL!
-            ])
-        }
-#endif
         try _throwIfPosixError(posix_spawnattr_init(&spawnAttrs))
         try _throwIfPosixError(posix_spawnattr_setflags(&spawnAttrs, .init(POSIX_SPAWN_SETPGROUP)))
 #if canImport(Darwin)

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -17,8 +17,8 @@ import WinSDK
 import Glibc
 #elseif canImport(Musl)
 import Musl
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // WORKAROUND_SR9811

--- a/Sources/plutil/main.swift
+++ b/Sources/plutil/main.swift
@@ -15,9 +15,9 @@ import Glibc
 #elseif canImport(Musl)
 import Foundation
 import Musl
-#elseif canImport(Android)
+#elseif canImport(Bionic)
 import Foundation
-import Android
+import Bionic
 #elseif canImport(CRT)
 import Foundation
 import CRT

--- a/Sources/xdgTestHelper/main.swift
+++ b/Sources/xdgTestHelper/main.swift
@@ -19,8 +19,8 @@ import FoundationNetworking
 #endif
 #if os(Windows)
 import WinSDK
-#elseif os(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 enum HelperCheckStatus : Int32 {

--- a/Tests/Foundation/FTPServer.swift
+++ b/Tests/Foundation/FTPServer.swift
@@ -15,8 +15,8 @@ import Dispatch
     import Glibc
 #elseif canImport(Darwin)
     import Darwin
-#elseif canImport(Android)
-    import Android
+#elseif canImport(Bionic)
+    import Bionic
 #endif
 
 final class ServerSemaphore : Sendable {

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -21,8 +21,8 @@ import Dispatch
     import Darwin
 #elseif canImport(Glibc)
     import Glibc
-#elseif canImport(Android)
-    import Android
+#elseif canImport(Bionic)
+    import Bionic
 #endif
 
 #if !os(Windows)

--- a/Tests/Foundation/TestFileHandle.swift
+++ b/Tests/Foundation/TestFileHandle.swift
@@ -19,8 +19,8 @@
 import Dispatch
 #if os(Windows)
 import WinSDK
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 class TestFileHandle : XCTestCase {

--- a/Tests/Foundation/TestProcess.swift
+++ b/Tests/Foundation/TestProcess.swift
@@ -8,8 +8,8 @@
 //
 
 import Synchronization
-#if canImport(Android)
-import Android
+#if canImport(Bionic)
+import Bionic
 #endif
 
 class TestProcess : XCTestCase {

--- a/Tests/Foundation/TestSocketPort.swift
+++ b/Tests/Foundation/TestSocketPort.swift
@@ -8,8 +8,8 @@
 //
 #if os(Windows)
 import WinSDK
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 class TestPortDelegateWithBlock: NSObject, PortDelegate {

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -7,8 +7,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-#if canImport(Android)
-import Android
+#if canImport(Bionic)
+import Bionic
 #endif
 
 let kURLTestParsingTestsKey = "ParsingTests"


### PR DESCRIPTION
Also, keep force unwrap for non-Android in `FileHandle._readDataOfLength()` and remove wrong `guard` for Android in `Process.run()`.